### PR TITLE
Puppet wasn't refreshing sysfsutils, this should fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,11 +7,11 @@ class sysfs {
             ensure => installed;
     }
 
-    service {
+    exec {
         "sysfsutils":
-            hasstatus  => false,
-            hasrestart => true,
-            subscribe  => File["/etc/sysfs.conf"];
+            command     => "service sysfsutils restart",
+            refreshonly => true,
+            subscribe   => File["/etc/sysfs.conf"];
     }
 
     concat {


### PR DESCRIPTION
Hi!

I was having trouble getting this module to actually apply the changes that it was adding to /etc/sysfs.conf. There was originally a service declaration for sysfsutils which subscribed to the /etc/sysfs.conf file. But, since sysfsutils is just an init script and doesn't spawn a service, puppet refused to refresh the service when the conf file changed:

Mar 20 10:51:40 mad7 puppet-agent[30323]: (/Stage[main]/Sysfs/Service[sysfsutils]) Skipping restart; service is not running

So, I've changed the service to an exec which calls restart on the init script (still subscribed to /etc/sysfs.conf), and now puppet is correctly applying new changes.
