### PR TITLE
Add initial support for RH-based systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,11 +7,23 @@ class sysfs {
             ensure => installed;
     }
 
-    exec {
+    case $osfamily {
+    /^(Debian|Ubuntu)$/: {
+      exec {
         "sysfsutils":
-            command     => "/usr/sbin/service sysfsutils restart",
-            refreshonly => true,
-            subscribe   => File["/etc/sysfs.conf"];
+          command     => "/usr/sbin/service sysfsutils restart",
+          refreshonly => true,
+          subscribe   => File["/etc/sysfs.conf"];
+      } 
+    }
+
+    'RedHat': { 
+        exec { 'sysfsutils_reload_rhel':
+          command => '/usr/bin/awk -F= \'/(\S+)\s*=(\S+)/{cmd=sprintf("/bin/echo %s > /sys/%s",$2, $1); system(cmd)}\' /etc/sysfs.conf',
+          refreshonly => true,
+          subscribe => File['/etc/sysfs.conf'];
+        } 
+      } 
     }
 
     concat {


### PR DESCRIPTION
Add initial support for RH-based systems that do not provide a sysfs "service," or even an init script.

This just looks for "redhattish" boxes based on $osfamily, and exec{} a short awk script to set values in /sys.  It's tested on Fedora boxes, but should work on other Red Hat-based distros (RHEL, CentOS, etc).
