### PR TITLE
Use ensure_packages to avoid redeclaration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,10 +2,7 @@ class sysfs {
 
     include concat::setup
 
-    package {
-        "sysfsutils":
-            ensure => installed;
-    }
+    ensure_packages(["sysfsutils"])
 
     case $osfamily {
     /^(Debian|Ubuntu)$/: {


### PR DESCRIPTION
This helps if you have other parts of your manifest which declare the same package. The only downside is that your package now depends on puppetlabs-stdlib with this. But I can't imagine an installation without the stdlib.
