### PR TITLE
fixing some unquoted values, particularly the file mode

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,9 +25,9 @@ class sysfs {
 
     concat {
         "/etc/sysfs.conf":
-            owner   => root,
-            group   => root,
-            mode    => 644,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0644',
             require => Package["sysfsutils"];
     }
 }


### PR DESCRIPTION
I believe that puppet 3.7 gets fairly upset with unquoted values (and I came across this when updating our codebase for a puppet 3.7 master). I've quoted some values here which were not quoted, and made the the file mode a string as recommended at https://docs.puppetlabs.com/references/latest/type.html#file-attribute-mode. Those docs are referencing the file type, but I assume the same should apply to the concat type.

Cheers!
