### PR TITLE
Remove concat::setup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,5 @@
 class sysfs {
 
-    include concat::setup
-
     ensure_packages(["sysfsutils"])
 
     case $osfamily {


### PR DESCRIPTION
This makes it compatible with recent versions of the concat module.

This is basically https://github.com/github/puppet-sysfs/pull/2, cherry-picked and with conflicts resolved.